### PR TITLE
URLクエリごとにスポット情報を返すハンドラの作成

### DIFF
--- a/pkg/server/handler/mock/spot.go
+++ b/pkg/server/handler/mock/spot.go
@@ -45,3 +45,15 @@ func (mr *MockSpotHandlerMockRecorder) HandleSpotCreate(w, r interface{}) *gomoc
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSpotCreate", reflect.TypeOf((*MockSpotHandler)(nil).HandleSpotCreate), w, r)
 }
+
+// HandleSpotGet mocks base method.
+func (m *MockSpotHandler) HandleSpotGet(w http.ResponseWriter, r *http.Request) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "HandleSpotGet", w, r)
+}
+
+// HandleSpotGet indicates an expected call of HandleSpotGet.
+func (mr *MockSpotHandlerMockRecorder) HandleSpotGet(w, r interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSpotGet", reflect.TypeOf((*MockSpotHandler)(nil).HandleSpotGet), w, r)
+}

--- a/pkg/server/handler/spot_test.go
+++ b/pkg/server/handler/spot_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	"github.com/tusmasoma/campfinder/db"
 	"github.com/tusmasoma/campfinder/db/mock"
 )
 
@@ -80,6 +82,69 @@ func TestSpotHandler_HandleSpotCreate(t *testing.T) {
 			recorder := httptest.NewRecorder()
 
 			handler.HandleSpotCreate(recorder, tt.in())
+
+			if status := recorder.Code; status != tt.wantStatus {
+				t.Fatalf("handler returned wrong status code: got %v want %v", status, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestSpotHandler_HandleSpotGet(t *testing.T) {
+	t.Parallel()
+	patterns := []struct {
+		name  string
+		setup func(
+			m *mock.MockSpotRepository,
+		)
+		in         func() *http.Request
+		wantStatus int
+	}{
+		{
+			name: "success",
+			setup: func(
+				m *mock.MockSpotRepository,
+			) {
+				m.EXPECT().GetSpotByCategory(gomock.Any(), "campsite").Return(
+					[]db.Spot{
+						{
+							ID:          uuid.MustParse("5c5323e9-c78f-4dac-94ef-d34ab5ea8fed"),
+							Category:    "campsite",
+							Name:        "旭川市21世紀の森ふれあい広場",
+							Address:     "北海道旭川市東旭川町瑞穂4288",
+							Lat:         43.7172721,
+							Lng:         142.6674615,
+							Period:      "2022年5月1日(日)〜11月30日(水)",
+							Phone:       "0166-76-2108",
+							Price:       "有料。ログハウス大人290円〜750円、高校生以下180〜460円",
+							Description: "旭川市21世紀の森ふれあい広場は、ペーパンダムの周辺に整備された多目的公園、旭川市21世紀の森に隣接するキャンプ場です。",
+							IconPath:    "/static/img/campsiteflag.jpeg",
+						},
+					}, nil,
+				)
+			},
+			in: func() *http.Request {
+				req, _ := http.NewRequest(http.MethodGet, "/api/spot?category=campsite", nil)
+				return req
+			},
+			wantStatus: http.StatusOK,
+		},
+	}
+	for _, tt := range patterns {
+		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			repo := mock.NewMockSpotRepository(ctrl)
+
+			if tt.setup != nil {
+				tt.setup(repo)
+			}
+
+			handler := NewSpotHandler(repo)
+			recorder := httptest.NewRecorder()
+
+			handler.HandleSpotGet(recorder, tt.in())
 
 			if status := recorder.Code; status != tt.wantStatus {
 				t.Fatalf("handler returned wrong status code: got %v want %v", status, tt.wantStatus)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -28,6 +28,7 @@ func Serve(addr string) {
 	spotHandler := handler.NewSpotHandler(spotRepo)
 
 	/* ===== URLマッピングを行う ===== */
+	http.HandleFunc("/api/spot", get(spotHandler.HandleSpotGet))
 	http.HandleFunc("/api/spot/create", post(spotHandler.HandleSpotCreate))
 
 	/* ===== サーバの設定 ===== */


### PR DESCRIPTION
## やったこと
URLクエリごとにスポット情報を返すハンドラの作成しました

## 詳細
- 現状は、存在しないURLクエリでもエラーはかえさない。存在するクエリのデータのみを返す
- 特定のcategoryの情報がデータベースから取得できないエラーが発生してもcontinueし、他のcategoryに関しては処理を続ける