### PR TITLE
JWTベースの認証ミドルウェアを作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .env
+
+# Privatekey and Publickey
+.certificate/

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -1,0 +1,196 @@
+package auth
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/tusmasoma/campfinder/db"
+)
+
+var (
+	PRIVATE_KEY_PATH = os.Getenv("PRIVATE_KEY_PATH")
+	PUBLIC_KEY_PATH  = os.Getenv("PUBLIC_KEY_PATH")
+)
+
+type Payload struct {
+	JTI    string `json:"jti"`
+	UserID string `json:"userId"`
+	//UserEmail string `json:"userEmail"`
+}
+
+const expectedTokenParts = 3
+
+func loadPrivateKeyFromFile(filename string) (*rsa.PrivateKey, error) {
+	// ファイルから秘密鍵をバイトスライスとして読み込む
+	keyBytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("error reading the key file: %w", err)
+	}
+
+	// PEMエンコードされたデータからPEMブロックをデコード
+	block, _ := pem.Decode(keyBytes)
+	if block == nil || (block.Type != "RSA PRIVATE KEY" && block.Type != "PRIVATE KEY") {
+		return nil, fmt.Errorf("failed to decode PEM block containing the key")
+	}
+
+	// PEMブロックからRSA秘密鍵をパース
+	privInterface, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse private key: %w", err)
+	}
+
+	privKey, ok := privInterface.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("not RSA private key")
+	}
+
+	return privKey, nil
+}
+
+func loadPublicKeyFromFile(filename string) (*rsa.PublicKey, error) {
+	// ファイルから公開鍵をバイトスライスとして読み込む
+	keyBytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("error reading the key file: %w", err)
+	}
+
+	// PEMエンコードされたデータからPEMブロックをデコード
+	block, _ := pem.Decode(keyBytes)
+	if block == nil || block.Type != "PUBLIC KEY" {
+		return nil, fmt.Errorf("failed to decode PEM block containing the key")
+	}
+
+	// PEMブロックからRSA公開鍵をパース
+	pubInterface, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse public key: %w", err)
+	}
+
+	pubKey, ok := pubInterface.(*rsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("not RSA public key")
+	}
+
+	return pubKey, nil
+}
+
+// Base64Urlエンコード
+func base64UrlEncode(b []byte) string {
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+// Base64Urlデコード
+func base64UrlDecode(s string) ([]byte, error) {
+	return base64.RawURLEncoding.DecodeString(s)
+}
+
+// アクセストークン(JWT形式)の生成
+func GenerateToken(user db.User) (jwt string, jti string) {
+	// ヘッダの作成
+	header := map[string]string{
+		"typ": "JWT",
+		"alg": "RS256",
+	}
+	headerBytes, _ := json.Marshal(header)
+	encodedHeader := base64UrlEncode(headerBytes)
+
+	// ペイロードの作成
+	jti = uuid.New().String()
+	payload := map[string]string{
+		"jti":      jti,
+		"userId":   user.ID.String(),
+		"userName": user.Name,
+	}
+	payloadBytes, _ := json.Marshal(payload)
+	encodedPayload := base64UrlEncode(payloadBytes)
+
+	// エンコードされたヘッダとペイロードを結合
+	jwtWithoutSignature := fmt.Sprintf("%s.%s", encodedHeader, encodedPayload)
+
+	// SHA-256ハッシュを計算
+	hashed := sha256.Sum256([]byte(jwtWithoutSignature))
+
+	// 署名作成
+
+	privKey, err := loadPrivateKeyFromFile(PRIVATE_KEY_PATH)
+	if err != nil {
+		panic(err)
+	}
+	signature, err := rsa.SignPKCS1v15(rand.Reader, privKey, crypto.SHA256, hashed[:])
+	if err != nil {
+		panic(err)
+	}
+	encodedSignature := base64UrlEncode(signature)
+
+	// JWTを完成
+	jwt = fmt.Sprintf("%s.%s", jwtWithoutSignature, encodedSignature)
+
+	return jwt, jti
+}
+
+func ValidateAccessToken(jwt string) error {
+	//　アクセストークンの検証
+	parts := strings.Split(jwt, ".")
+	if len(parts) != expectedTokenParts {
+		return fmt.Errorf("invalid token")
+	}
+	// エンコードされたヘッダとペイロードを結合
+	jwtWithoutSignature := fmt.Sprintf("%s.%s", parts[0], parts[1])
+	// SHA-256ハッシュを計算
+	hashed := sha256.Sum256([]byte(jwtWithoutSignature))
+
+	// 著名作成
+	signature, err := base64UrlDecode(parts[2])
+	if err != nil {
+		return fmt.Errorf("decoding failed: %w", err)
+	}
+
+	// 検証
+	pubKey, err := loadPublicKeyFromFile(PUBLIC_KEY_PATH)
+	if err != nil {
+		return err
+	}
+
+	err = rsa.VerifyPKCS1v15(pubKey, crypto.SHA256, hashed[:], signature)
+	if err != nil {
+		return fmt.Errorf("signature verification failed: %w", err)
+	}
+
+	return nil
+}
+
+func GetPayloadFromToken(jwt string) (Payload, error) {
+	var emptyPayload Payload
+	//　アクセストークンの検証
+	parts := strings.Split(jwt, ".")
+	if len(parts) != expectedTokenParts {
+		return emptyPayload, fmt.Errorf("invalid token")
+	}
+	// エンコードされたヘッダとペイロードを結合
+	encodedPayload := parts[1]
+	// Base64Urlデコード
+	payloadBytes, err := base64UrlDecode(encodedPayload)
+	if err != nil {
+		return emptyPayload, fmt.Errorf("decoding failed: %w", err)
+	}
+
+	// JSONデコード
+	var payload Payload
+	err = json.Unmarshal(payloadBytes, &payload)
+	if err != nil {
+		return emptyPayload, fmt.Errorf("JSON unmarshalling failed")
+	}
+
+	return payload, nil
+}

--- a/pkg/http/middleware/auth.go
+++ b/pkg/http/middleware/auth.go
@@ -1,0 +1,86 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/tusmasoma/campfinder/cache"
+	"github.com/tusmasoma/campfinder/internal/auth"
+)
+
+type AuthMiddleware interface {
+	Authenticate(nextFunc http.HandlerFunc) http.HandlerFunc
+}
+
+type authMiddleware struct {
+	rr cache.RedisRepository
+}
+
+func NewAuthMiddleware(rr cache.RedisRepository) AuthMiddleware {
+	return &authMiddleware{
+		rr: rr,
+	}
+}
+
+// Authenticate ユーザ認証を行ってContextへユーザID情報を保存する
+func (am *authMiddleware) Authenticate(nextFunc http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		// リクエストヘッダにAuthorizationが存在するか確認
+		authHeader := r.Header.Get("Authorization")
+		if authHeader == "" {
+			http.Error(w, "Authentication failed: missing Authorization header", http.StatusUnauthorized)
+			return
+		}
+
+		// "Bearer "から始まるか確認
+		parts := strings.Split(authHeader, " ")
+		if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+			http.Error(w, "Authorization failed: header format must be Bearer {token}", http.StatusUnauthorized)
+			return
+		}
+		jwt := parts[1]
+
+		//　アクセストークンの検証
+		err := auth.ValidateAccessToken(jwt)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Authentication failed: %v", err), http.StatusUnauthorized)
+			return
+		}
+
+		// JWTからペイロード取得
+		var payload auth.Payload
+		payload, err = auth.GetPayloadFromToken(jwt)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Authentication failed: %v", err), http.StatusUnauthorized)
+			return
+		}
+
+		// 該当のuserIdが存在するかキャッシュに問い合わせ
+		jti, err := am.rr.Get(ctx, payload.UserID)
+		if errors.Is(err, cache.ErrCacheMiss) {
+			http.Error(w, "Authentication failed: userId is not exit on cache", http.StatusUnauthorized)
+			return
+		} else if err != nil {
+			http.Error(w, "Authentication failed: missing userId on cache", http.StatusUnauthorized)
+			return
+		}
+
+		// Redisから取得したjtiとJWTのjtiを比較
+		if payload.JTI != jti {
+			http.Error(w, "Authentication failed: jwt does not match", http.StatusUnauthorized)
+			return
+		}
+
+		// 今後有効期限の確認も行う
+
+		// コンテキストに userID を保存
+		ctx = context.WithValue(ctx, "userID", payload.UserID)
+
+		nextFunc(w, r.WithContext(ctx))
+	}
+}


### PR DESCRIPTION
## やったこと
JWT認証ミドルウェア実装

## 詳細
Authenticateミドルウェアにて、リクエストのAuthorizationからアクセストークンを取得し、検証し認可処理を行う。

## シーケンス図
以下が認証ミドルウェアのシーケンス図。
![275709823-500be28f-8c59-4be4-a43a-c772ecaa1361](https://github.com/tusmasoma/campfinder/assets/104899572/edb617fc-5e0b-4430-9be9-3019dcf75365)
