### PR TITLE
コメントの取得・作成・更新・削除するハンドラの作成

### DIFF
--- a/db/comment.go
+++ b/db/comment.go
@@ -10,11 +10,11 @@ import (
 )
 
 type CommentRepository interface {
-	GetCommentBySpotID(ctx context.Context, spotID uuid.UUID, opts ...QueryOptions) (comments []Comment, err error)
-	GetCommentByID(ctx context.Context, id uuid.UUID, opts ...QueryOptions) (comment Comment, err error)
+	GetCommentBySpotID(ctx context.Context, spotID string, opts ...QueryOptions) (comments []Comment, err error)
+	GetCommentByID(ctx context.Context, id string, opts ...QueryOptions) (comment Comment, err error)
 	Create(ctx context.Context, comment Comment, opts ...QueryOptions) (err error)
 	Update(ctx context.Context, comment Comment, opts ...QueryOptions) (err error)
-	Delete(ctx context.Context, id uuid.UUID, opts ...QueryOptions) (err error)
+	Delete(ctx context.Context, id string, opts ...QueryOptions) (err error)
 }
 
 type commentRepository struct {
@@ -36,7 +36,7 @@ type Comment struct {
 	Created  time.Time
 }
 
-func (cr *commentRepository) GetCommentBySpotID(ctx context.Context, spotID uuid.UUID, opts ...QueryOptions) (comments []Comment, err error) {
+func (cr *commentRepository) GetCommentBySpotID(ctx context.Context, spotID string, opts ...QueryOptions) (comments []Comment, err error) {
 	var executor SQLExecutor = cr.db
 	if len(opts) > 0 && opts[0].Executor != nil {
 		executor = opts[0].Executor
@@ -71,7 +71,7 @@ func (cr *commentRepository) GetCommentBySpotID(ctx context.Context, spotID uuid
 	return
 }
 
-func (cr *commentRepository) GetCommentByID(ctx context.Context, id uuid.UUID, opts ...QueryOptions) (comment Comment, err error) {
+func (cr *commentRepository) GetCommentByID(ctx context.Context, id string, opts ...QueryOptions) (comment Comment, err error) {
 	var executor SQLExecutor = cr.db
 	if len(opts) > 0 && opts[0].Executor != nil {
 		executor = opts[0].Executor
@@ -133,7 +133,7 @@ func (cr *commentRepository) Update(ctx context.Context, comment Comment, opts .
 	return
 }
 
-func (cr *commentRepository) Delete(ctx context.Context, id uuid.UUID, opts ...QueryOptions) (err error) {
+func (cr *commentRepository) Delete(ctx context.Context, id string, opts ...QueryOptions) (err error) {
 	var executor SQLExecutor = cr.db
 	if len(opts) > 0 && opts[0].Executor != nil {
 		executor = opts[0].Executor

--- a/db/mock/comment.go
+++ b/db/mock/comment.go
@@ -9,7 +9,6 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	uuid "github.com/google/uuid"
 	db "github.com/tusmasoma/campfinder/db"
 )
 
@@ -56,7 +55,7 @@ func (mr *MockCommentRepositoryMockRecorder) Create(ctx, comment interface{}, op
 }
 
 // Delete mocks base method.
-func (m *MockCommentRepository) Delete(ctx context.Context, id uuid.UUID, opts ...db.QueryOptions) error {
+func (m *MockCommentRepository) Delete(ctx context.Context, id string, opts ...db.QueryOptions) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, id}
 	for _, a := range opts {
@@ -75,7 +74,7 @@ func (mr *MockCommentRepositoryMockRecorder) Delete(ctx, id interface{}, opts ..
 }
 
 // GetCommentByID mocks base method.
-func (m *MockCommentRepository) GetCommentByID(ctx context.Context, id uuid.UUID, opts ...db.QueryOptions) (db.Comment, error) {
+func (m *MockCommentRepository) GetCommentByID(ctx context.Context, id string, opts ...db.QueryOptions) (db.Comment, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, id}
 	for _, a := range opts {
@@ -95,7 +94,7 @@ func (mr *MockCommentRepositoryMockRecorder) GetCommentByID(ctx, id interface{},
 }
 
 // GetCommentBySpotID mocks base method.
-func (m *MockCommentRepository) GetCommentBySpotID(ctx context.Context, spotID uuid.UUID, opts ...db.QueryOptions) ([]db.Comment, error) {
+func (m *MockCommentRepository) GetCommentBySpotID(ctx context.Context, spotID string, opts ...db.QueryOptions) ([]db.Comment, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, spotID}
 	for _, a := range opts {

--- a/pkg/server/handler/comment.go
+++ b/pkg/server/handler/comment.go
@@ -102,7 +102,7 @@ func isValidateCommentCreateRequest(body io.ReadCloser, requestBody *CommentCrea
 		log.Printf("Invalid request body: %v", err)
 		return false
 	}
-	if requestBody.SpotID.String() == "" || requestBody.StarRate == 0 || requestBody.Text == "" {
+	if requestBody.SpotID.String() == "00000000-0000-0000-0000-000000000000" || requestBody.StarRate == 0 || requestBody.Text == "" {
 		log.Printf("Missing required fields")
 		return false
 	}
@@ -141,8 +141,8 @@ func (ch *commentHandler) HandleCommentUpdate(w http.ResponseWriter, r *http.Req
 	}
 	defer r.Body.Close()
 
-	if user.ID != requestBody.UserID {
-		http.Error(w, "User ID mismatch", http.StatusBadRequest)
+	if !user.IsAdmin && user.ID != requestBody.UserID {
+		http.Error(w, "User ID mismatch", http.StatusInternalServerError)
 		return
 	}
 
@@ -159,7 +159,7 @@ func isValidateCommentUpdateRequest(body io.ReadCloser, requestBody *CommentUpda
 		log.Printf("Invalid request body: %v", err)
 		return false
 	}
-	if requestBody.ID.String() == "" || requestBody.SpotID.String() == "" || requestBody.UserID.String() == "" || requestBody.StarRate == 0 || requestBody.Text == "" {
+	if requestBody.ID.String() == "00000000-0000-0000-0000-000000000000" || requestBody.SpotID.String() == "00000000-0000-0000-0000-000000000000" || requestBody.UserID.String() == "00000000-0000-0000-0000-000000000000" || requestBody.StarRate == 0 || requestBody.Text == "" {
 		log.Printf("Missing required fields")
 		return false
 	}
@@ -197,8 +197,8 @@ func (ch *commentHandler) HandleCommentDelete(w http.ResponseWriter, r *http.Req
 	}
 	defer r.Body.Close()
 
-	if user.ID != requestBody.UserID {
-		http.Error(w, "User ID mismatch", http.StatusBadRequest)
+	if !user.IsAdmin && user.ID != requestBody.UserID {
+		http.Error(w, "User ID mismatch", http.StatusInternalServerError)
 		return
 	}
 
@@ -215,7 +215,7 @@ func isValidateCommentDeleteRequest(body io.ReadCloser, requestBody *CommentDele
 		log.Printf("Invalid request body: %v", err)
 		return false
 	}
-	if requestBody.ID.String() == "" || requestBody.UserID.String() == "" {
+	if requestBody.ID.String() == "00000000-0000-0000-0000-000000000000" || requestBody.UserID.String() == "00000000-0000-0000-0000-000000000000" {
 		log.Printf("Missing required fields")
 		return false
 	}

--- a/pkg/server/handler/comment.go
+++ b/pkg/server/handler/comment.go
@@ -1,0 +1,223 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/tusmasoma/campfinder/db"
+	"github.com/tusmasoma/campfinder/internal/auth"
+)
+
+type CommentCreateRequest struct {
+	SpotID   uuid.UUID `json:"spotID"`
+	StarRate float64   `json:"starRate"`
+	Text     string    `json:"text"`
+}
+
+type CommentUpdateRequest struct {
+	ID       uuid.UUID `json:"id"`
+	SpotID   uuid.UUID `json:"spotID"`
+	UserID   uuid.UUID `json:"userID"`
+	StarRate float64   `json:"starRate"`
+	Text     string    `json:"text"`
+}
+
+type CommentDeleteRequest struct {
+	ID     uuid.UUID `json:"id"`
+	UserID uuid.UUID `json:"userID"`
+}
+
+type CommentGetResponse struct {
+	Comments []db.Comment
+}
+
+type CommentHandler interface {
+	HandleCommentCreate(w http.ResponseWriter, r *http.Request)
+	HandleCommentGet(w http.ResponseWriter, r *http.Request)
+	HandleCommentUpdate(w http.ResponseWriter, r *http.Request)
+	HandleCommentDelete(w http.ResponseWriter, r *http.Request)
+}
+
+type commentHandler struct {
+	cr db.CommentRepository
+	ah auth.AuthHandler
+}
+
+func NewCommentHandler(cr db.CommentRepository, ah auth.AuthHandler) CommentHandler {
+	return &commentHandler{
+		cr: cr,
+		ah: ah,
+	}
+}
+
+func (ch *commentHandler) HandleCommentGet(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	spotID := r.URL.Query().Get("spot_id")
+
+	comments, err := ch.cr.GetCommentBySpotID(ctx, spotID)
+	if err != nil {
+		http.Error(w, "Failed to get comments by spot id", http.StatusInternalServerError)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(CommentGetResponse{Comments: comments}); err != nil {
+		http.Error(w, "Failed to encode spots to JSON", http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+}
+
+func (ch *commentHandler) HandleCommentCreate(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// ユーザー情報取得
+	user, err := ch.ah.FetchUserFromContext(ctx)
+	if err != nil {
+		http.Error(w, "Failed to get UserInfo from context", http.StatusInternalServerError)
+		return
+	}
+
+	var requestBody CommentCreateRequest
+	if ok := isValidateCommentCreateRequest(r.Body, &requestBody); !ok {
+		http.Error(w, "Invalid comment create request", http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	if err := ch.CommentCreate(ctx, user, requestBody); err != nil {
+		http.Error(w, "Internal server error while creating comment", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func isValidateCommentCreateRequest(body io.ReadCloser, requestBody *CommentCreateRequest) bool {
+	if err := json.NewDecoder(body).Decode(requestBody); err != nil {
+		log.Printf("Invalid request body: %v", err)
+		return false
+	}
+	if requestBody.SpotID.String() == "" || requestBody.StarRate == 0 || requestBody.Text == "" {
+		log.Printf("Missing required fields")
+		return false
+	}
+	return true
+}
+
+func (ch *commentHandler) CommentCreate(ctx context.Context, user db.User, requestBody CommentCreateRequest) error {
+
+	var comment = db.Comment{
+		SpotID:   requestBody.SpotID,
+		UserID:   user.ID,
+		StarRate: requestBody.StarRate,
+		Text:     requestBody.Text,
+	}
+
+	if err := ch.cr.Create(ctx, comment); err != nil {
+		log.Printf("Failed to create comment: %v", err)
+		return err
+	}
+	return nil
+}
+
+func (ch *commentHandler) HandleCommentUpdate(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	user, err := ch.ah.FetchUserFromContext(ctx)
+	if err != nil {
+		http.Error(w, "Failed to get UserInfo from context", http.StatusInternalServerError)
+		return
+	}
+
+	var requestBody CommentUpdateRequest
+	if ok := isValidateCommentUpdateRequest(r.Body, &requestBody); !ok {
+		http.Error(w, "Invalid comment update request", http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	if user.ID != requestBody.UserID {
+		http.Error(w, "User ID mismatch", http.StatusBadRequest)
+		return
+	}
+
+	if err := ch.CommentUpdate(ctx, requestBody); err != nil {
+		http.Error(w, "Internal server error while updating comment", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func isValidateCommentUpdateRequest(body io.ReadCloser, requestBody *CommentUpdateRequest) bool {
+	if err := json.NewDecoder(body).Decode(requestBody); err != nil {
+		log.Printf("Invalid request body: %v", err)
+		return false
+	}
+	if requestBody.ID.String() == "" || requestBody.SpotID.String() == "" || requestBody.UserID.String() == "" || requestBody.StarRate == 0 || requestBody.Text == "" {
+		log.Printf("Missing required fields")
+		return false
+	}
+	return true
+}
+
+func (ch *commentHandler) CommentUpdate(ctx context.Context, requestBody CommentUpdateRequest) error {
+	var comment = db.Comment{
+		ID:       requestBody.ID,
+		SpotID:   requestBody.SpotID,
+		UserID:   requestBody.UserID,
+		StarRate: requestBody.StarRate,
+		Text:     requestBody.Text,
+	}
+	if err := ch.cr.Update(ctx, comment); err != nil {
+		log.Printf("Failed to update comment: %v", err)
+		return err
+	}
+	return nil
+}
+
+func (ch *commentHandler) HandleCommentDelete(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	user, err := ch.ah.FetchUserFromContext(ctx)
+	if err != nil {
+		http.Error(w, "Failed to get UserInfo from context", http.StatusInternalServerError)
+		return
+	}
+
+	var requestBody CommentDeleteRequest
+	if ok := isValidateCommentDeleteRequest(r.Body, &requestBody); !ok {
+		http.Error(w, "Invalid comment delete request", http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	if user.ID != requestBody.UserID {
+		http.Error(w, "User ID mismatch", http.StatusBadRequest)
+		return
+	}
+
+	if err := ch.cr.Delete(ctx, requestBody.ID.String()); err != nil {
+		http.Error(w, "Internal server error while deleting comment", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func isValidateCommentDeleteRequest(body io.ReadCloser, requestBody *CommentDeleteRequest) bool {
+	if err := json.NewDecoder(body).Decode(requestBody); err != nil {
+		log.Printf("Invalid request body: %v", err)
+		return false
+	}
+	if requestBody.ID.String() == "" || requestBody.UserID.String() == "" {
+		log.Printf("Missing required fields")
+		return false
+	}
+	return true
+}

--- a/pkg/server/handler/comment_test.go
+++ b/pkg/server/handler/comment_test.go
@@ -1,0 +1,479 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	"github.com/tusmasoma/campfinder/db"
+	dbmock "github.com/tusmasoma/campfinder/db/mock"
+	authmock "github.com/tusmasoma/campfinder/internal/auth/mock"
+)
+
+func TestCommentHandler_HandleCommentGet(t *testing.T) {
+	t.Parallel()
+	patterns := []struct {
+		name  string
+		setup func(
+			m *dbmock.MockCommentRepository,
+		)
+		in         func() *http.Request
+		wantStatus int
+	}{
+		{
+			name: "success",
+			setup: func(
+				m *dbmock.MockCommentRepository,
+			) {
+				const layout = "2006-01-02T15:04:05Z"
+				created, _ := time.Parse(layout, "0001-01-01T00:00:00Z")
+				m.EXPECT().GetCommentBySpotID(gomock.Any(), "fb816fc7-ddcf-4fa0-9be0-d1fd0b8b5052").Return(
+					[]db.Comment{
+						{
+							ID:       uuid.New(),
+							SpotID:   uuid.MustParse("fb816fc7-ddcf-4fa0-9be0-d1fd0b8b5052"),
+							UserID:   uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e6eec2"),
+							StarRate: 2,
+							Text:     "いいスポットでした!!!",
+							Created:  created,
+						},
+					}, nil,
+				)
+			},
+			in: func() *http.Request {
+				req, _ := http.NewRequest(http.MethodGet, "/api/comment?spot_id=fb816fc7-ddcf-4fa0-9be0-d1fd0b8b5052", nil)
+				return req
+			},
+			wantStatus: http.StatusOK,
+		},
+	}
+	for _, tt := range patterns {
+		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			repo := dbmock.NewMockCommentRepository(ctrl)
+			mockAuthHandler := authmock.NewMockAuthHandler(ctrl)
+
+			if tt.setup != nil {
+				tt.setup(repo)
+			}
+
+			handler := NewCommentHandler(repo, mockAuthHandler)
+			recorder := httptest.NewRecorder()
+
+			handler.HandleCommentGet(recorder, tt.in())
+
+			if status := recorder.Code; status != tt.wantStatus {
+				t.Fatalf("handler returned wrong status code: got %v want %v", status, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestCommentHandler_HandleCommentCreate(t *testing.T) {
+	t.Parallel()
+	patterns := []struct {
+		name  string
+		setup func(
+			m *dbmock.MockCommentRepository,
+			m1 *authmock.MockAuthHandler,
+		)
+		in         func() *http.Request
+		wantStatus int
+	}{
+		{
+			name: "success",
+			setup: func(
+				m *dbmock.MockCommentRepository,
+				m1 *authmock.MockAuthHandler,
+			) {
+				passward, _ := db.PasswordEncrypt("password123")
+				m1.EXPECT().FetchUserFromContext(gomock.Any()).Return(db.User{
+					ID:       uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e6eec2"),
+					Name:     "test",
+					Email:    "test@gmail.com",
+					Password: passward,
+					IsAdmin:  false,
+				}, nil)
+				m.EXPECT().Create(gomock.Any(), db.Comment{
+					SpotID:   uuid.MustParse("fb816fc7-ddcf-4fa0-9be0-d1fd0b8b5052"),
+					UserID:   uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e6eec2"),
+					StarRate: 3,
+					Text:     "いいスポットでした！",
+				}).Return(nil)
+			},
+			in: func() *http.Request {
+				commentCreateReq := CommentCreateRequest{
+					SpotID:   uuid.MustParse("fb816fc7-ddcf-4fa0-9be0-d1fd0b8b5052"),
+					StarRate: 3,
+					Text:     "いいスポットでした！",
+				}
+				reqBody, _ := json.Marshal(commentCreateReq)
+				req, _ := http.NewRequest(http.MethodPost, "/api/comment/create", bytes.NewBuffer(reqBody))
+				req.Header.Set("Content-Type", "application/json")
+				return req
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "Fail: invalid request",
+			setup: func(m *dbmock.MockCommentRepository, m1 *authmock.MockAuthHandler) {
+				passward, _ := db.PasswordEncrypt("password123")
+				m1.EXPECT().FetchUserFromContext(gomock.Any()).Return(db.User{
+					ID:       uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e6eec2"),
+					Name:     "test",
+					Email:    "test@gmail.com",
+					Password: passward,
+					IsAdmin:  false,
+				}, nil)
+			},
+			in: func() *http.Request {
+				commentCreateReq := CommentCreateRequest{
+					SpotID:   uuid.MustParse("fb816fc7-ddcf-4fa0-9be0-d1fd0b8b5052"),
+					StarRate: 3,
+				}
+				reqBody, _ := json.Marshal(commentCreateReq)
+				req, _ := http.NewRequest(http.MethodPost, "/api/comment/create", bytes.NewBuffer(reqBody))
+				req.Header.Set("Content-Type", "application/json")
+				return req
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+	for _, tt := range patterns {
+		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			repo := dbmock.NewMockCommentRepository(ctrl)
+			mockAuthHandler := authmock.NewMockAuthHandler(ctrl)
+
+			if tt.setup != nil {
+				tt.setup(repo, mockAuthHandler)
+			}
+
+			handler := NewCommentHandler(repo, mockAuthHandler)
+			recorder := httptest.NewRecorder()
+
+			handler.HandleCommentCreate(recorder, tt.in())
+
+			if status := recorder.Code; status != tt.wantStatus {
+				t.Fatalf("handler returned wrong status code: got %v want %v", status, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestCommentHandler_HandleCommentUpdate(t *testing.T) {
+	t.Parallel()
+	patterns := []struct {
+		name  string
+		setup func(
+			m *dbmock.MockCommentRepository,
+			m1 *authmock.MockAuthHandler,
+		)
+		in         func() *http.Request
+		wantStatus int
+	}{
+		{
+			name: "success",
+			setup: func(
+				m *dbmock.MockCommentRepository,
+				m1 *authmock.MockAuthHandler,
+			) {
+				passward, _ := db.PasswordEncrypt("password123")
+				m1.EXPECT().FetchUserFromContext(gomock.Any()).Return(db.User{
+					ID:       uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e6eec2"),
+					Name:     "test",
+					Email:    "test@gmail.com",
+					Password: passward,
+					IsAdmin:  false,
+				}, nil)
+				m.EXPECT().Update(gomock.Any(), db.Comment{
+					ID:       uuid.MustParse("31894386-3e60-45a8-bc67-f46b72b42554"),
+					SpotID:   uuid.MustParse("fb816fc7-ddcf-4fa0-9be0-d1fd0b8b5052"),
+					UserID:   uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e6eec2"),
+					StarRate: 5,
+					Text:     "いいスポットでした！!!",
+				}).Return(nil)
+			},
+			in: func() *http.Request {
+				commentUpdateReq := CommentUpdateRequest{
+					ID:       uuid.MustParse("31894386-3e60-45a8-bc67-f46b72b42554"),
+					SpotID:   uuid.MustParse("fb816fc7-ddcf-4fa0-9be0-d1fd0b8b5052"),
+					UserID:   uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e6eec2"),
+					StarRate: 5,
+					Text:     "いいスポットでした！!!",
+				}
+				reqBody, _ := json.Marshal(commentUpdateReq)
+				req, _ := http.NewRequest(http.MethodPost, "/api/comment/update", bytes.NewBuffer(reqBody))
+				req.Header.Set("Content-Type", "application/json")
+				return req
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "success: Super User",
+			setup: func(
+				m *dbmock.MockCommentRepository,
+				m1 *authmock.MockAuthHandler,
+			) {
+				passward, _ := db.PasswordEncrypt("password123")
+				m1.EXPECT().FetchUserFromContext(gomock.Any()).Return(db.User{
+					ID:       uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e61234"),
+					Name:     "super_user",
+					Email:    "super_user@gmail.com",
+					Password: passward,
+					IsAdmin:  true,
+				}, nil)
+				m.EXPECT().Update(gomock.Any(), db.Comment{
+					ID:       uuid.MustParse("31894386-3e60-45a8-bc67-f46b72b42554"),
+					SpotID:   uuid.MustParse("fb816fc7-ddcf-4fa0-9be0-d1fd0b8b5052"),
+					UserID:   uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e6eec2"),
+					StarRate: 5,
+					Text:     "いいスポットでした！!!",
+				}).Return(nil)
+			},
+			in: func() *http.Request {
+				commentUpdateReq := CommentUpdateRequest{
+					ID:       uuid.MustParse("31894386-3e60-45a8-bc67-f46b72b42554"),
+					SpotID:   uuid.MustParse("fb816fc7-ddcf-4fa0-9be0-d1fd0b8b5052"),
+					UserID:   uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e6eec2"),
+					StarRate: 5,
+					Text:     "いいスポットでした！!!",
+				}
+				reqBody, _ := json.Marshal(commentUpdateReq)
+				req, _ := http.NewRequest(http.MethodPost, "/api/comment/update", bytes.NewBuffer(reqBody))
+				req.Header.Set("Content-Type", "application/json")
+				return req
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "Fail: invalid request",
+			setup: func(m *dbmock.MockCommentRepository, m1 *authmock.MockAuthHandler) {
+				passward, _ := db.PasswordEncrypt("password123")
+				m1.EXPECT().FetchUserFromContext(gomock.Any()).Return(db.User{
+					ID:       uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e6eec2"),
+					Name:     "test",
+					Email:    "test@gmail.com",
+					Password: passward,
+					IsAdmin:  false,
+				}, nil)
+			},
+			in: func() *http.Request {
+				commentUpdateReq := CommentUpdateRequest{
+					ID:       uuid.MustParse("31894386-3e60-45a8-bc67-f46b72b42554"),
+					SpotID:   uuid.MustParse("fb816fc7-ddcf-4fa0-9be0-d1fd0b8b5052"),
+					UserID:   uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e6eec2"),
+					StarRate: 5,
+				}
+				reqBody, _ := json.Marshal(commentUpdateReq)
+				req, _ := http.NewRequest(http.MethodPost, "/api/comment/update", bytes.NewBuffer(reqBody))
+				req.Header.Set("Content-Type", "application/json")
+				return req
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "Fail: Not authorized to update",
+			setup: func(
+				m *dbmock.MockCommentRepository,
+				m1 *authmock.MockAuthHandler,
+			) {
+				passward, _ := db.PasswordEncrypt("password123")
+				m1.EXPECT().FetchUserFromContext(gomock.Any()).Return(db.User{
+					ID:       uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e61234"),
+					Name:     "test",
+					Email:    "test@gmail.com",
+					Password: passward,
+					IsAdmin:  false,
+				}, nil)
+			},
+			in: func() *http.Request {
+				commentUpdateReq := CommentUpdateRequest{
+					ID:       uuid.MustParse("31894386-3e60-45a8-bc67-f46b72b42554"),
+					SpotID:   uuid.MustParse("fb816fc7-ddcf-4fa0-9be0-d1fd0b8b5052"),
+					UserID:   uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e6eec2"),
+					StarRate: 5,
+					Text:     "いいスポットでした！!!",
+				}
+				reqBody, _ := json.Marshal(commentUpdateReq)
+				req, _ := http.NewRequest(http.MethodPost, "/api/comment/update", bytes.NewBuffer(reqBody))
+				req.Header.Set("Content-Type", "application/json")
+				return req
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+	}
+	for _, tt := range patterns {
+		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			repo := dbmock.NewMockCommentRepository(ctrl)
+			mockAuthHandler := authmock.NewMockAuthHandler(ctrl)
+
+			if tt.setup != nil {
+				tt.setup(repo, mockAuthHandler)
+			}
+
+			handler := NewCommentHandler(repo, mockAuthHandler)
+			recorder := httptest.NewRecorder()
+
+			handler.HandleCommentUpdate(recorder, tt.in())
+
+			if status := recorder.Code; status != tt.wantStatus {
+				t.Fatalf("handler returned wrong status code: got %v want %v", status, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestCommentHandler_HandleCommentDelete(t *testing.T) {
+	t.Parallel()
+	patterns := []struct {
+		name  string
+		setup func(
+			m *dbmock.MockCommentRepository,
+			m1 *authmock.MockAuthHandler,
+		)
+		in         func() *http.Request
+		wantStatus int
+	}{
+		{
+			name: "success",
+			setup: func(
+				m *dbmock.MockCommentRepository,
+				m1 *authmock.MockAuthHandler,
+			) {
+				passward, _ := db.PasswordEncrypt("password123")
+				m1.EXPECT().FetchUserFromContext(gomock.Any()).Return(db.User{
+					ID:       uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e6eec2"),
+					Name:     "test",
+					Email:    "test@gmail.com",
+					Password: passward,
+					IsAdmin:  false,
+				}, nil)
+				m.EXPECT().Delete(gomock.Any(), "31894386-3e60-45a8-bc67-f46b72b42554").Return(nil)
+			},
+			in: func() *http.Request {
+				commentDeleteReq := CommentDeleteRequest{
+					ID:     uuid.MustParse("31894386-3e60-45a8-bc67-f46b72b42554"),
+					UserID: uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e6eec2"),
+				}
+				reqBody, _ := json.Marshal(commentDeleteReq)
+				req, _ := http.NewRequest(http.MethodPost, "/api/comment/delete", bytes.NewBuffer(reqBody))
+				req.Header.Set("Content-Type", "application/json")
+				return req
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "success: Super User",
+			setup: func(
+				m *dbmock.MockCommentRepository,
+				m1 *authmock.MockAuthHandler,
+			) {
+				passward, _ := db.PasswordEncrypt("password123")
+				m1.EXPECT().FetchUserFromContext(gomock.Any()).Return(db.User{
+					ID:       uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e61234"),
+					Name:     "super_user",
+					Email:    "super_user@gmail.com",
+					Password: passward,
+					IsAdmin:  true,
+				}, nil)
+				m.EXPECT().Delete(gomock.Any(), "31894386-3e60-45a8-bc67-f46b72b42554").Return(nil)
+			},
+			in: func() *http.Request {
+				commentDeleteReq := CommentDeleteRequest{
+					ID:     uuid.MustParse("31894386-3e60-45a8-bc67-f46b72b42554"),
+					UserID: uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e6eec2"),
+				}
+				reqBody, _ := json.Marshal(commentDeleteReq)
+				req, _ := http.NewRequest(http.MethodPost, "/api/comment/delete", bytes.NewBuffer(reqBody))
+				req.Header.Set("Content-Type", "application/json")
+				return req
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "Fail: invalid request",
+			setup: func(m *dbmock.MockCommentRepository, m1 *authmock.MockAuthHandler) {
+				passward, _ := db.PasswordEncrypt("password123")
+				m1.EXPECT().FetchUserFromContext(gomock.Any()).Return(db.User{
+					ID:       uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e6eec2"),
+					Name:     "test",
+					Email:    "test@gmail.com",
+					Password: passward,
+					IsAdmin:  false,
+				}, nil)
+			},
+			in: func() *http.Request {
+				commentDeleteReq := CommentDeleteRequest{
+					ID: uuid.MustParse("31894386-3e60-45a8-bc67-f46b72b42554"),
+				}
+				reqBody, _ := json.Marshal(commentDeleteReq)
+				req, _ := http.NewRequest(http.MethodPost, "/api/comment/delete", bytes.NewBuffer(reqBody))
+				req.Header.Set("Content-Type", "application/json")
+				return req
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "Fail: Not authorized to update",
+			setup: func(
+				m *dbmock.MockCommentRepository,
+				m1 *authmock.MockAuthHandler,
+			) {
+				passward, _ := db.PasswordEncrypt("password123")
+				m1.EXPECT().FetchUserFromContext(gomock.Any()).Return(db.User{
+					ID:       uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e61234"),
+					Name:     "test",
+					Email:    "test@gmail.com",
+					Password: passward,
+					IsAdmin:  false,
+				}, nil)
+			},
+			in: func() *http.Request {
+				commentDeleteReq := CommentDeleteRequest{
+					ID:     uuid.MustParse("31894386-3e60-45a8-bc67-f46b72b42554"),
+					UserID: uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e6eec2"),
+				}
+				reqBody, _ := json.Marshal(commentDeleteReq)
+				req, _ := http.NewRequest(http.MethodPost, "/api/comment/delete", bytes.NewBuffer(reqBody))
+				req.Header.Set("Content-Type", "application/json")
+				return req
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+	}
+	for _, tt := range patterns {
+		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			repo := dbmock.NewMockCommentRepository(ctrl)
+			mockAuthHandler := authmock.NewMockAuthHandler(ctrl)
+
+			if tt.setup != nil {
+				tt.setup(repo, mockAuthHandler)
+			}
+
+			handler := NewCommentHandler(repo, mockAuthHandler)
+			recorder := httptest.NewRecorder()
+
+			handler.HandleCommentDelete(recorder, tt.in())
+
+			if status := recorder.Code; status != tt.wantStatus {
+				t.Fatalf("handler returned wrong status code: got %v want %v: %v", status, tt.wantStatus, tt.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## やったこと
コメントの取得・作成・更新・削除するハンドラの作成

## 詳細
- 更新・削除はコメントの作成者にしか操作できないように記述
- スーパーユーザーは、コメントの作成者でなくても編集・削除を行えるようにした