### PR TITLE
mainブランチ以外へのPush時はCIのみ、mainブランチへのMerge時はCIおよびCDを実行

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -18,6 +18,8 @@ permissions:
   contents: read
 
 jobs:
+  ci:
+    uses: ./.github/workflows/ci.yaml
   deploy:
     name: Deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,26 +1,21 @@
-# This is a basic workflow to help you get started with Actions
 
 name: CI
 
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
-    branches: [ "main" ]
+    paths-ignore:
+      - '**/*.md'
+    branches-ignore:
+      - main
+    branches: [ "develop" ]
   pull_request:
-    branches: [ "main" ]
-
-  # Allows you to run this workflow manually from the Actions tab
+    branches: [ "develop" ]
+  workflow_call:
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3.5.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,6 @@ on:
       - '**/*.md'
     branches-ignore:
       - main
-    branches: [ "develop" ]
   pull_request:
     branches: [ "develop" ]
   workflow_call:


### PR DESCRIPTION
## やったこと
今後、以下のブランチに大きく分けて開発を進めていく
- mainブランチ(本番環境用)
- developブランチ(開発環境用)

上記から、mainブランチ以外へのPush時はCIのみ、mainブランチへのMerge時はCIおよびCDを実行するようにwarkflowかいた。