### PR TITLE
goでchiする

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: 1.55.2
+          version: v1.55.2
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cleanup

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: latest
+          version: 1.55.2
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cleanup

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -234,7 +234,7 @@ linters:
     - nolintlint # reports ill-formed or insufficient nolint directives
     - nonamedreturns # reports all named returns
     - nosprintfhostport # checks for misuse of Sprintf to construct a host with port in a URL
-    - perfsprint # checks that fmt.Sprintf can be replaced with a faster alternative
+    #- perfsprint # checks that fmt.Sprintf can be replaced with a faster alternative
     - predeclared # finds code that shadows one of Go's predeclared identifiers
     - promlinter # checks Prometheus metrics naming via promlint
     - protogetter # reports direct reads from proto message fields when getters should be used

--- a/config/server.go
+++ b/config/server.go
@@ -3,10 +3,11 @@ package config
 import "time"
 
 const (
-	ReadTimeout             = 5 * time.Second
-	WriteTimeout            = 10 * time.Second
-	IdleTimeout             = 15 * time.Second
-	GracefulShutdownTimeout = 5 * time.Second
+	ReadTimeout                   = 5 * time.Second
+	WriteTimeout                  = 10 * time.Second
+	IdleTimeout                   = 15 * time.Second
+	GracefulShutdownTimeout       = 5 * time.Second
+	PreflightCacheDurationSeconds = 300
 )
 
 type ContextKey string

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,11 @@ require github.com/joho/godotenv v1.5.1
 require github.com/google/uuid v1.5.0
 
 require (
+	github.com/go-chi/chi/v5 v5.0.11
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/golang/mock v1.6.0
+	github.com/google/go-cmp v0.6.0
 	github.com/ory/dockertest v3.3.5+incompatible
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/crypto v0.18.0
@@ -30,7 +32,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
+	github.com/go-chi/cors v1.2.1 // indirect
 	github.com/gotestyourself/gotestyourself v2.2.0+incompatible // indirect
 	github.com/lib/pq v0.0.0-20180327071824-d34b9ff171c2 // indirect
 	github.com/onsi/gomega v1.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,10 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/go-chi/chi/v5 v5.0.11 h1:BnpYbFZ3T3S1WMpD79r7R5ThWX40TaFB7L31Y8xqSwA=
+github.com/go-chi/chi/v5 v5.0.11/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/go-chi/cors v1.2.1 h1:xEC8UT3Rlp2QuWNEr4Fs/c2EAGVKBwy/1vHx3bppil4=
+github.com/go-chi/cors v1.2.1/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
 github.com/go-redis/redis/v8 v8.11.5 h1:AcZZR7igkdvfVmQTPnu9WE37LRrO/YrBH5zWyjDC0oI=
 github.com/go-redis/redis/v8 v8.11.5/go.mod h1:gREzHqY1hg6oD9ngVRbLStwAWKhA0FEgq8Jd4h5lpwo=
 github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrtU8EI=

--- a/interfaces/middleware/auth.go
+++ b/interfaces/middleware/auth.go
@@ -17,7 +17,7 @@ import (
 var ErrCacheMiss = errors.New("cache: key not found")
 
 type AuthMiddleware interface {
-	Authenticate(nextFunc http.HandlerFunc) http.HandlerFunc
+	Authenticate(nextFunc http.Handler) http.Handler
 }
 
 type authMiddleware struct {
@@ -31,8 +31,8 @@ func NewAuthMiddleware(rr repository.CacheRepository) AuthMiddleware {
 }
 
 // Authenticate ユーザ認証を行ってContextへユーザID情報を保存する
-func (am *authMiddleware) Authenticate(nextFunc http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+func (am *authMiddleware) Authenticate(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
 		// リクエストヘッダにAuthorizationが存在するか確認
@@ -87,6 +87,6 @@ func (am *authMiddleware) Authenticate(nextFunc http.HandlerFunc) http.HandlerFu
 		// コンテキストに userID を保存
 		ctx = context.WithValue(ctx, config.ContextUserIDKey, payload.UserID)
 
-		nextFunc(w, r.WithContext(ctx))
-	}
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
 }

--- a/interfaces/middleware/logging.go
+++ b/interfaces/middleware/logging.go
@@ -18,11 +18,11 @@ func (lrw *loggingResponseWriter) WriteHeader(statusCode int) {
 	lrw.ResponseWriter.WriteHeader(statusCode)
 }
 
-func Logging(nextFunc http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+func Logging(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		lrw := &loggingResponseWriter{ResponseWriter: w}
 
-		nextFunc(lrw, r)
+		next.ServeHTTP(lrw, r)
 		// アクセスログ
 		log.Printf("[ACCESS] Date: %s, URL: %s, IP: %s, StatusCode: %d",
 			time.Now().Format("2006-01-02 15:04:05"), r.URL, r.RemoteAddr, lrw.statusCode)
@@ -32,5 +32,5 @@ func Logging(nextFunc http.HandlerFunc) http.HandlerFunc {
 			log.Printf("[ERROR] Date: %s, URL: %s, StatusCode: %d",
 				time.Now().Format("2006-01-02 15:04:05"), r.URL, lrw.statusCode)
 		}
-	}
+	})
 }

--- a/interfaces/middleware/mock/auth.go
+++ b/interfaces/middleware/mock/auth.go
@@ -35,10 +35,10 @@ func (m *MockAuthMiddleware) EXPECT() *MockAuthMiddlewareMockRecorder {
 }
 
 // Authenticate mocks base method.
-func (m *MockAuthMiddleware) Authenticate(nextFunc http.HandlerFunc) http.HandlerFunc {
+func (m *MockAuthMiddleware) Authenticate(nextFunc http.Handler) http.Handler {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Authenticate", nextFunc)
-	ret0, _ := ret[0].(http.HandlerFunc)
+	ret0, _ := ret[0].(http.Handler)
 	return ret0
 }
 


### PR DESCRIPTION
## やったこと
`net/http`で十分でしたが、ルーティング周りが冗長になってきた為、`chi`を使って解決しました。

ginやechoより薄いため、ルーティングとミドルウェアのみの変更だけで済みます。

## ドキュメント
https://go-chi.io/#/README
https://pkg.go.dev/github.com/go-chi/chi/v5@v5.0.11#Router.Use