### PR TITLE
create Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,99 @@
+# golang settings
+GO ?= go
+GOLINT ?= golangci-lint
+GOOS := $(shell $(GO) env GOOS)
+GOARCH := $(shell $(GO) env GOARCH)
+BIN := $(abspath ./bin/$(GOOS)_$(GOARCH))
+GO_ENV ?= GOPRIVATE=github.com/tusmasoma GOBIN=$(BIN)
+
+# tools
+$(shell mkdir -p $(BIN))
+
+GOLANGCI_LINT_VERSION := v1.55.2
+$(BIN)/golangci-lint-$(GOLANGCI_LINT_VERSION):
+	unlink $(BIN)/golangci-lint || true
+	$(GO_ENV) ${GO} install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	mv $(BIN)/golangci-lint $(BIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
+	ln -s $(BIN)/golangci-lint-$(GOLANGCI_LINT_VERSION) $(BIN)/golangci-lint
+
+REVIEWDOG_VERSION := v0.12.0
+$(BIN)/reviewdog:
+    curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/$(REVIEWDOG_VERSION)/install.sh | sh -s -- -b $(BIN) $(REVIEWDOG_VERSION)
+
+MOCKGEN_VERSION := v1.6.0
+$(BIN)/mockgen-$(MOCKGEN_VERSION):
+	unlink $(BIN)/mockgen || true
+	$(GO_ENV) ${GO} install github.com/golang/mock/mockgen@v$(MOCKGEN_VERSION)
+	mv $(BIN)/mockgen $(BIN)/mockgen-$(MOCKGEN_VERSION)
+	ln -s $(BIN)/mockgen-$(MOCKGEN_VERSION) $(BIN)/mockgen
+
+GOIMPORTS_VERSION := v0.19.0
+$(BIN)/goimports-$(GOIMPORTS_VERSION):
+	unlink $(BIN)/goimports || true
+	$(GO_ENV) ${GO} install golang.org/x/tools/cmd/goimports@$(GOIMPORTS_VERSION)
+	mv $(BIN)/goimports $(BIN)/goimports-$(GOIMPORTS_VERSION)
+	ln -s $(BIN)/goimports-$(GOIMPORTS_VERSION) $(BIN)/goimports
+
+GOFUMPT_VERSION := v0.6.0
+$(BIN)/gofumpt-$(GOFUMPT_VERSION):
+	unlink $(BIN)/gofumpt || true
+	$(GO_ENV) ${GO} install mvdan.cc/gofumpt@$(GOFUMPT_VERSION)
+	mv $(BIN)/gofumpt $(BIN)/gofumpt-$(GOFUMPT_VERSION)
+	ln -s $(BIN)/gofumpt-$(GOFUMPT_VERSION) $(BIN)/gofumpt
+
+# テストターゲット: テストを実行
+.PHONY: test
+test:
+	cd docker/back/ && $(GO) test ${TESTABLE}
+
+.PHONY: test-all
+test-all:
+    cd docker/back/ && $(GO) test -v -count=1 ./...
+
+# golangci-lint: lint for all under the PKG
+.PHONY: lint
+lint: PKG ?= ./docker/back/...
+lint: $(BIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
+	$(BIN)/golangci-lint run -c ./docker/back/.golangci.yaml $(PKG)
+
+# golangci-lint: lint for all go files have diff
+.PHONY: lint-diff
+lint-diff: PKG ?= ./docker/back/...
+lint-diff: $(BIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
+	$(BIN)/golangci-lint run -c ./docker/back/.golangci.yaml $(PKG) | reviewdog -f=golangci-lint -diff="git diff origin/develop"
+
+.PHONY: fmt
+fmt: $(BIN)/goimports-$(GOIMPORTS_VERSION) $(BIN)/gofumpt-$(GOFUMPT_VERSION)
+	FILES=$$(find ./docker/back -type f -name "*.go") && \
+	${GO_ENV} $(BIN)/goimports -local "github.com/tusmasoma/campfinder/docker/back" -w $${FILES} && \
+	${GO_ENV} $(BIN)/gofumpt -l -w $${FILES}
+
+.PHONY: generate
+generate: generate-deps
+	@for dir in $$(find ./docker/back -maxdepth 1 -type d | sed '1,1d' | sed 's@./@@') ; do \
+		if [ -n "$$(git diff --name-only origin/develop "$${dir}")" ]; then \
+			echo "go generate ./$${dir}/..." && \
+			PATH="$(BIN):$(PATH)" ${GO_ENV} ${GO} generate "./$${dir}/..." || exit 1; \
+		fi; \
+	done
+	$(MAKE) fmt
+
+.PHONY: generate-all
+generate-all: generate-deps
+	@PATH="$(BIN):$(PATH)" ${GO_ENV} ${GO} generate ./docker/back/...
+	$(MAKE) fmt
+
+.PHONY: generate-deps
+generate-deps: $(BIN)/mockgen-$(MOCKGEN_VERSION)
+
+.PHONY: tidy
+tidy:
+    cd docker/back/ && $(GO) mod tidy
+
+.PHONY: build
+build:
+    $(GO) build -v ./docker/back/...
+
+.PHONY: bin-clean
+bin-clean:
+	$(RM) -r ./bin


### PR DESCRIPTION
## やったこと
このプルリクエストでは、Goプロジェクトのビルドおよび開発プロセスを合理化するために、Makefileを作成しました。

## 詳細
- テスト用の新しいターゲットを追加：`test` は特定のテストを実行し、`test-all` はキャッシュを無効にしてすべてのテストを実行します。
- `lint` ターゲットを強化して、特定のパッケージの下にあるすべてのファイルをリントするようにし、`lint-diff` を追加して、`develop` ブランチへの最後のコミット以降に変更されたファイルのみをリントするようにしました。
- `goimports` と `gofumpt` を使用してGoファイルをフォーマットするための `fmt` ターゲットを導入しました。
- 変更されたディレクトリまたはすべてのディレクトリで `go generate` を実行するための `generate` および `generate-all` ターゲットを追加しました。
- コード生成を実行する前に必要なツール（例：`mockgen`）がインストールされていることを保証するための `generate-deps` ターゲットを作成しました。
- `bin` ディレクトリをクリーンアップするための `bin-clean` ターゲットを含めました。

これらにより、開発ワークフローの効率を向上させ、コード品質およびフォーマットの一貫性を確保することを目的としています。