### PR TITLE
カテゴリ別のスポット取得を並行処理で実装

### DIFF
--- a/docker/back/usecase/spot_test.go
+++ b/docker/back/usecase/spot_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/tusmasoma/campfinder/docker/back/domain/model"
 	"github.com/tusmasoma/campfinder/docker/back/domain/repository"
@@ -301,9 +302,7 @@ func TestSpotUseCase_ListSpots(t *testing.T) {
 
 			spots := usecase.ListSpots(tt.arg.ctx, tt.arg.categories)
 
-			if !reflect.DeepEqual(spots, tt.want) {
-				t.Errorf("ListSpots() \n got = %v,\n want %v", spots, tt.want)
-			}
+			assert.ElementsMatch(t, tt.want, spots, "ListSpots() should return the correct set of spots regardless of order")
 		})
 	}
 }


### PR DESCRIPTION
## やったこと

- ListSpots関数において、与えられたカテゴリごとにスポット情報を非同期に取得するように変更しました。
- 各カテゴリのスポットデータ取得をゴルーチンを用いて並行処理することで、処理時間の短縮を図ります。
- スポットデータのリストへの追加はsync.Mutexを使用してスレッドセーフに行います。