### PR TITLE
feat: batch create comment in usecase

### DIFF
--- a/docker/back/domain/repository/comment.go
+++ b/docker/back/domain/repository/comment.go
@@ -11,6 +11,7 @@ type CommentRepository interface {
 	List(ctx context.Context, qcs []QueryCondition) ([]model.Comment, error)
 	Get(ctx context.Context, id string) (*model.Comment, error)
 	Create(ctx context.Context, comment model.Comment) error
+	BatchCreate(ctx context.Context, comments []model.Comment) error
 	Update(ctx context.Context, id string, comment model.Comment) error
 	Delete(ctx context.Context, id string) error
 }

--- a/docker/back/domain/repository/mock/comment.go
+++ b/docker/back/domain/repository/mock/comment.go
@@ -37,6 +37,20 @@ func (m *MockCommentRepository) EXPECT() *MockCommentRepositoryMockRecorder {
 	return m.recorder
 }
 
+// BatchCreate mocks base method.
+func (m *MockCommentRepository) BatchCreate(ctx context.Context, comments []model.Comment) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BatchCreate", ctx, comments)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BatchCreate indicates an expected call of BatchCreate.
+func (mr *MockCommentRepositoryMockRecorder) BatchCreate(ctx, comments interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchCreate", reflect.TypeOf((*MockCommentRepository)(nil).BatchCreate), ctx, comments)
+}
+
 // Create mocks base method.
 func (m *MockCommentRepository) Create(ctx context.Context, comment model.Comment) error {
 	m.ctrl.T.Helper()

--- a/docker/back/interfaces/handler/comment.go
+++ b/docker/back/interfaces/handler/comment.go
@@ -16,6 +16,7 @@ import (
 type CommentHandler interface {
 	ListComments(w http.ResponseWriter, r *http.Request)
 	CreateComment(w http.ResponseWriter, r *http.Request)
+	BatchCreateComments(w http.ResponseWriter, r *http.Request)
 	UpdateComment(w http.ResponseWriter, r *http.Request)
 	DeleteComment(w http.ResponseWriter, r *http.Request)
 }
@@ -36,6 +37,10 @@ type CreateCommentRequest struct {
 	SpotID   uuid.UUID `json:"spotID"`
 	StarRate float64   `json:"starRate"`
 	Text     string    `json:"text"`
+}
+
+type BatchCreateCommentsRequest struct {
+	Comments []CreateCommentRequest `json:"comments"`
 }
 
 type UpdateCommentRequest struct {
@@ -82,7 +87,8 @@ func (ch *commentHandler) CreateComment(w http.ResponseWriter, r *http.Request) 
 	}
 	defer r.Body.Close()
 
-	if err = ch.cuc.CreateComment(ctx, requestBody.SpotID, requestBody.StarRate, requestBody.Text, *user); err != nil {
+	params := convertCreateCommentReqeuestToParams(requestBody, user.ID)
+	if err = ch.cuc.CreateComment(ctx, params); err != nil {
 		http.Error(w, "Internal server error while creating comment", http.StatusInternalServerError)
 		return
 	}
@@ -100,6 +106,71 @@ func isValidateCreateCommentRequest(body io.ReadCloser, requestBody *CreateComme
 		return false
 	}
 	return true
+}
+
+func convertCreateCommentReqeuestToParams(req CreateCommentRequest, userID uuid.UUID) *usecase.CreateCommentParams {
+	return &usecase.CreateCommentParams{
+		UserID:   userID,
+		SpotID:   req.SpotID,
+		StarRate: req.StarRate,
+		Text:     req.Text,
+	}
+}
+
+func (ch *commentHandler) BatchCreateComments(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user, err := ch.auc.GetUserFromContext(ctx)
+	if err != nil {
+		http.Error(w, "Failed to get UserInfo from context", http.StatusInternalServerError)
+		return
+	}
+
+	var requestBody BatchCreateCommentsRequest
+	if ok := isValidateBatchCreateCommentsRequest(r.Body, &requestBody); !ok {
+		http.Error(w, "Invalid comment batch create request", http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	params := convertBatchCreateCommentsRequestToParams(requestBody, user.ID)
+	if err = ch.cuc.BatchCreateComments(ctx, params); err != nil {
+		http.Error(w, "Internal server error while batch creating comments", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func isValidateBatchCreateCommentsRequest(body io.ReadCloser, requestBody *BatchCreateCommentsRequest) bool {
+	if err := json.NewDecoder(body).Decode(requestBody); err != nil {
+		log.Printf("Invalid request body: %v", err)
+		return false
+	}
+	for _, comment := range requestBody.Comments {
+		if comment.SpotID.String() == DefaultUUID || comment.StarRate == 0 || comment.Text == "" {
+			log.Printf("Missing required fields")
+			return false
+		}
+	}
+	return true
+}
+
+func convertBatchCreateCommentsRequestToParams(
+	req BatchCreateCommentsRequest,
+	userID uuid.UUID,
+) *usecase.BatchCreateCommentsParams {
+	var comments []usecase.CreateCommentParams
+	for _, commentReq := range req.Comments {
+		comments = append(comments, usecase.CreateCommentParams{
+			UserID:   userID,
+			SpotID:   commentReq.SpotID,
+			StarRate: commentReq.StarRate,
+			Text:     commentReq.Text,
+		})
+	}
+	return &usecase.BatchCreateCommentsParams{
+		Comments: comments,
+	}
 }
 
 func (ch *commentHandler) UpdateComment(w http.ResponseWriter, r *http.Request) {

--- a/docker/back/interfaces/handler/mock/comment.go
+++ b/docker/back/interfaces/handler/mock/comment.go
@@ -34,6 +34,18 @@ func (m *MockCommentHandler) EXPECT() *MockCommentHandlerMockRecorder {
 	return m.recorder
 }
 
+// BatchCreateComments mocks base method.
+func (m *MockCommentHandler) BatchCreateComments(w http.ResponseWriter, r *http.Request) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "BatchCreateComments", w, r)
+}
+
+// BatchCreateComments indicates an expected call of BatchCreateComments.
+func (mr *MockCommentHandlerMockRecorder) BatchCreateComments(w, r interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchCreateComments", reflect.TypeOf((*MockCommentHandler)(nil).BatchCreateComments), w, r)
+}
+
 // CreateComment mocks base method.
 func (m *MockCommentHandler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	m.ctrl.T.Helper()

--- a/docker/back/usecase/comment.go
+++ b/docker/back/usecase/comment.go
@@ -14,7 +14,7 @@ import (
 
 type CommentUseCase interface {
 	ListComments(ctx context.Context, spotID string) ([]model.Comment, error)
-	CreateComment(ctx context.Context, spotID uuid.UUID, starRate float64, text string, user model.User) error
+	CreateComment(ctx context.Context, params *CreateCommentParams) error
 	BatchCreateComments(ctx context.Context, params *BatchCreateCommentsParams) error
 	UpdateComment(
 		ctx context.Context,
@@ -54,24 +54,18 @@ func (cuc *commentUseCase) ListComments(ctx context.Context, spotID string) ([]m
 }
 
 type CreateCommentParams struct {
+	UserID   uuid.UUID
 	SpotID   uuid.UUID
 	StarRate float64
 	Text     string
-	userID   uuid.UUID
 }
 
-func (cuc *commentUseCase) CreateComment(
-	ctx context.Context,
-	spotID uuid.UUID,
-	starRate float64,
-	text string,
-	user model.User,
-) error {
+func (cuc *commentUseCase) CreateComment(ctx context.Context, params *CreateCommentParams) error {
 	comment := model.Comment{
-		SpotID:   spotID,
-		UserID:   user.ID,
-		StarRate: starRate,
-		Text:     text,
+		SpotID:   params.SpotID,
+		UserID:   params.UserID,
+		StarRate: params.StarRate,
+		Text:     params.Text,
 	}
 
 	if err := cuc.cr.Create(ctx, comment); err != nil {
@@ -89,8 +83,8 @@ func (cuc *commentUseCase) BatchCreateComments(ctx context.Context, params *Batc
 	var comments []model.Comment
 	for _, param := range params.Comments {
 		comment := model.Comment{
+			UserID:   param.UserID,
 			SpotID:   param.SpotID,
-			UserID:   param.userID,
 			StarRate: param.StarRate,
 			Text:     param.Text,
 		}

--- a/docker/back/usecase/comment_test.go
+++ b/docker/back/usecase/comment_test.go
@@ -220,6 +220,85 @@ func TestCommentUseCase_CreateComment(t *testing.T) {
 	}
 }
 
+func TestCommentuseCase_BatchCreateComments(t *testing.T) {
+	t.Parallel()
+	patterns := []struct {
+		name  string
+		setup func(
+			m *mock.MockCommentRepository,
+		)
+		params  *BatchCreateCommentsParams
+		wantErr error
+	}{
+		{
+			name: "success",
+			setup: func(m *mock.MockCommentRepository) {
+				comments := []model.Comment{
+					{
+						SpotID:   uuid.MustParse("fb816fc7-ddcf-4fa0-9be0-d1fd0b8b5052"),
+						UserID:   uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e6eec2"),
+						StarRate: 5.0,
+						Text:     "いいスポットでした！!!",
+					},
+					{
+						SpotID:   uuid.MustParse("fb816fc7-ddcf-4fa0-9be0-d1fd0b505312"),
+						UserID:   uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e6eec3"),
+						StarRate: 4.0,
+						Text:     "最高のスポットでした！!!",
+					},
+				}
+				m.EXPECT().BatchCreate(
+					gomock.Any(),
+					comments,
+				).Return(nil)
+			},
+			params: &BatchCreateCommentsParams{
+				Comments: []CreateCommentParams{
+					{
+						SpotID:   uuid.MustParse("fb816fc7-ddcf-4fa0-9be0-d1fd0b8b5052"),
+						StarRate: 5.0,
+						Text:     "いいスポットでした！!!",
+						userID:   uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e6eec2"),
+					},
+					{
+						SpotID:   uuid.MustParse("fb816fc7-ddcf-4fa0-9be0-d1fd0b505312"),
+						StarRate: 4.0,
+						Text:     "最高のスポットでした！!!",
+						userID:   uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e6eec3"),
+					},
+				},
+			},
+			wantErr: nil,
+		},
+	}
+	for _, tt := range patterns {
+		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			cr := mock.NewMockCommentRepository(ctrl)
+			cc := mock.NewMockCommentsCacheRepository(ctrl)
+
+			if tt.setup != nil {
+				tt.setup(cr)
+			}
+
+			usecase := NewCommentUseCase(cr, cc)
+
+			err := usecase.BatchCreateComments(
+				context.Background(),
+				tt.params,
+			)
+
+			if (err != nil) != (tt.wantErr != nil) {
+				t.Errorf("BatchCreateComments() error = %v, wantErr %v", err, tt.wantErr)
+			} else if err != nil && tt.wantErr != nil && err.Error() != tt.wantErr.Error() {
+				t.Errorf("BatchCreateComments() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestCommentUseCase_UpdateComment(t *testing.T) {
 	t.Parallel()
 	patterns := []struct {

--- a/docker/back/usecase/comment_test.go
+++ b/docker/back/usecase/comment_test.go
@@ -15,14 +15,6 @@ import (
 	"github.com/tusmasoma/campfinder/docker/back/domain/repository/mock"
 )
 
-type CommentCreateArg struct {
-	ctx      context.Context
-	spotID   uuid.UUID
-	starRate float64
-	text     string
-	user     model.User
-}
-
 type CommentUpdateArg struct {
 	ctx      context.Context
 	id       uuid.UUID
@@ -160,12 +152,14 @@ func TestCommentUseCase_ListComments(t *testing.T) {
 
 func TestCommentUseCase_CreateComment(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
+
 	patterns := []struct {
 		name  string
 		setup func(
 			m *mock.MockCommentRepository,
 		)
-		arg     CommentCreateArg
+		params  *CreateCommentParams
 		wantErr error
 	}{
 		{
@@ -179,18 +173,11 @@ func TestCommentUseCase_CreateComment(t *testing.T) {
 				}
 				m.EXPECT().Create(gomock.Any(), comment).Return(nil)
 			},
-			arg: CommentCreateArg{
-				ctx:      context.Background(),
-				spotID:   uuid.MustParse("fb816fc7-ddcf-4fa0-9be0-d1fd0b8b5052"),
-				starRate: 5.0,
-				text:     "いいスポットでした！!!",
-				user: model.User{
-					ID:       uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e6eec2"),
-					Name:     "test",
-					Email:    "test@gmail.com",
-					Password: "password123",
-					IsAdmin:  false,
-				},
+			params: &CreateCommentParams{
+				UserID:   uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e6eec2"),
+				SpotID:   uuid.MustParse("fb816fc7-ddcf-4fa0-9be0-d1fd0b8b5052"),
+				StarRate: 5.0,
+				Text:     "いいスポットでした！!!",
 			},
 			wantErr: nil,
 		},
@@ -209,7 +196,7 @@ func TestCommentUseCase_CreateComment(t *testing.T) {
 
 			usecase := NewCommentUseCase(cr, cc)
 
-			err := usecase.CreateComment(tt.arg.ctx, tt.arg.spotID, tt.arg.starRate, tt.arg.text, tt.arg.user)
+			err := usecase.CreateComment(ctx, tt.params)
 
 			if (err != nil) != (tt.wantErr != nil) {
 				t.Errorf("CommentCreate() error = %v, wantErr %v", err, tt.wantErr)
@@ -258,13 +245,13 @@ func TestCommentuseCase_BatchCreateComments(t *testing.T) {
 						SpotID:   uuid.MustParse("fb816fc7-ddcf-4fa0-9be0-d1fd0b8b5052"),
 						StarRate: 5.0,
 						Text:     "いいスポットでした！!!",
-						userID:   uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e6eec2"),
+						UserID:   uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e6eec2"),
 					},
 					{
 						SpotID:   uuid.MustParse("fb816fc7-ddcf-4fa0-9be0-d1fd0b505312"),
 						StarRate: 4.0,
 						Text:     "最高のスポットでした！!!",
-						userID:   uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e6eec3"),
+						UserID:   uuid.MustParse("f6db2530-cd9b-4ac1-8dc1-38c795e6eec3"),
 					},
 				},
 			},

--- a/docker/back/usecase/mock/comment.go
+++ b/docker/back/usecase/mock/comment.go
@@ -53,17 +53,17 @@ func (mr *MockCommentUseCaseMockRecorder) BatchCreateComments(ctx, params interf
 }
 
 // CreateComment mocks base method.
-func (m *MockCommentUseCase) CreateComment(ctx context.Context, spotID uuid.UUID, starRate float64, text string, user model.User) error {
+func (m *MockCommentUseCase) CreateComment(ctx context.Context, params *usecase.CreateCommentParams) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateComment", ctx, spotID, starRate, text, user)
+	ret := m.ctrl.Call(m, "CreateComment", ctx, params)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateComment indicates an expected call of CreateComment.
-func (mr *MockCommentUseCaseMockRecorder) CreateComment(ctx, spotID, starRate, text, user interface{}) *gomock.Call {
+func (mr *MockCommentUseCaseMockRecorder) CreateComment(ctx, params interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateComment", reflect.TypeOf((*MockCommentUseCase)(nil).CreateComment), ctx, spotID, starRate, text, user)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateComment", reflect.TypeOf((*MockCommentUseCase)(nil).CreateComment), ctx, params)
 }
 
 // DeleteComment mocks base method.

--- a/docker/back/usecase/mock/comment.go
+++ b/docker/back/usecase/mock/comment.go
@@ -12,6 +12,7 @@ import (
 	uuid "github.com/google/uuid"
 
 	model "github.com/tusmasoma/campfinder/docker/back/domain/model"
+	usecase "github.com/tusmasoma/campfinder/docker/back/usecase"
 )
 
 // MockCommentUseCase is a mock of CommentUseCase interface.
@@ -35,6 +36,20 @@ func NewMockCommentUseCase(ctrl *gomock.Controller) *MockCommentUseCase {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCommentUseCase) EXPECT() *MockCommentUseCaseMockRecorder {
 	return m.recorder
+}
+
+// BatchCreateComments mocks base method.
+func (m *MockCommentUseCase) BatchCreateComments(ctx context.Context, params *usecase.BatchCreateCommentsParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BatchCreateComments", ctx, params)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BatchCreateComments indicates an expected call of BatchCreateComments.
+func (mr *MockCommentUseCaseMockRecorder) BatchCreateComments(ctx, params interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchCreateComments", reflect.TypeOf((*MockCommentUseCase)(nil).BatchCreateComments), ctx, params)
 }
 
 // CreateComment mocks base method.


### PR DESCRIPTION
## やったこと
このプルリクエストでは、`BatchCreateComments` ハンドラを新たに実装しました。これまで、コメントのデータをデータベースに一つ一つ挿入していた方法では、大量のデータ操作時に高い負荷がかかり、効率も低下していました。`BatchCreateHandler` は、これらのコメントデータをまとめて挿入する機能を提供することで、データベースへの書き込み効率を大幅に改善します。

### 主な変更点
- `BatchCreateComments`ハンドラの実装により、複数のコメントデータを一度に挿入可能。
- 既存の挿入処理と比較して、大量のデータも迅速に処理できるようになります。

### 影響範囲
- コメントデータの挿入を行うAPIエンドポイントに影響がありますが、外部からのAPI仕様は変わりません。

### テスト
- 新しいバッチ挿入機能のユニットテストを追加しました。
- 実際のデータを使用した統合テストを行い、既存の機能との互換性を確認しました。

この変更により、アプリケーションのパフォーマンスとスケーラビリティが向上することが期待されます。
